### PR TITLE
[IN PROGRESS] Add currency/money mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pattern used in masked components:
 
 Ex: AAA-9999
 
-## Usage (MaskedTextInput)
+### Usage MaskedTextInput (custom)
 
 Component similar with `<TextInput />` but with custom mask option.
 
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-## Usage (MaskedText)
+### Usage MaskedText (custom)
 
 Component similar with `<Text />` but with custom mask option.
 
@@ -65,6 +65,81 @@ import { MaskedText } from "react-native-mask-text";
 //...
 
 <MaskedText mask="99/99/9999">30081990</MaskedText>;
+```
+
+## Currency Mask
+
+These options only are used if you use prop `type="currency"` in your component:
+
+| Option                 | Type   | Mandatory | Default Value | Description                                 |
+|------------------------|--------|-----------|---------------|---------------------------------------------|
+| prefix                 | string | No        | null          | String to prepend                           |
+| decimalSeparator       | string | No        | null          | Separation for decimals                     |
+| groupSeparator         | string | No        | null          | Grouping separator of the integer part      |
+| precision              | number | No        | 0             | Precision for fraction part (cents)         |
+| groupSize              | number | No        | 3             | Primary grouping size of the integer part   |
+| secondaryGroupSize     | number | No        | null          | Secondary grouping size of the integer part |
+| fractionGroupSeparator | string | No        | null          | Grouping separator of the fraction part     |
+| fractionGroupSize      | number | No        | null          | Grouping size of the fraction part          |
+| suffix                 | string | No        | null          | String to append                            |
+
+### Usage MaskedTextInput (currency)
+
+Component similar with `<TextInput />` but with currency mask option.
+
+```jsx
+import { StyleSheet } from "react-native";
+import { MaskedTextInput } from "react-native-mask-text";
+
+//...
+
+<MaskedTextInput
+  type="currency"
+  options={{
+    prefix: '$',
+    decimalSeparator: '.',
+    groupSeparator: ',',
+    precision: 2
+  }}
+  onChangeText={(text, rawText) => {
+    console.log(text);
+    console.log(rawText);
+  }}
+  style={styles.input}
+  keyboardType="numeric"
+/>
+
+//...
+
+const styles = StyleSheet.create({
+  input: {
+    height: 40,
+    margin: 12,
+    borderWidth: 1,
+  },
+});
+```
+
+### Usage MaskedText (currency)
+
+Component similar with `<Text />` but with currency mask option.
+
+```jsx
+import { MaskedText } from "react-native-mask-text";
+
+//...
+
+<MaskedText
+  type="currency"
+  options={{
+    prefix: '$',
+    decimalSeparator: '.',
+    groupSeparator: ',',
+    precision: 2
+  }}
+>
+  5999
+</MaskedText>;
 ```
 
 ## Usage `mask` function

--- a/example/App.js
+++ b/example/App.js
@@ -6,6 +6,9 @@ export default function App() {
   const [maskedValue, setMaskedValue] = useState("");
   const [unMaskedValue, setUnmaskedValue] = useState("");
 
+  const [currencyMaskedValue, setCurrencyMaskedValue] = useState("");
+  const [currencyUnMaskedValue, setCurrencyUnmaskedValue] = useState("");
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>MaskedTextInput Component:</Text>
@@ -20,6 +23,25 @@ export default function App() {
       />
       <Text style={styles.paragraph}>Raw Text: {unMaskedValue}</Text>
       <Text style={styles.paragraph}>Masked Text: {maskedValue}</Text>
+
+      <Text style={styles.title}>MaskedTextInput Component with Currency:</Text>
+      <MaskedTextInput
+        type="currency"
+        options={{
+          prefix: '$',
+          decimalSeparator: '.',
+          groupSeparator: ',',
+          precision: 2
+        }}
+        onChangeText={(text, rawText) => {
+          setCurrencyMaskedValue(text);
+          setCurrencyUnmaskedValue(rawText);
+        }}
+        style={styles.input}
+        keyboardType="numeric"
+      />
+      <Text style={styles.paragraph}>Raw Text: {currencyUnMaskedValue}</Text>
+      <Text style={styles.paragraph}>Masked Text: {currencyMaskedValue}</Text>
 
       <Text style={styles.title}>MaskedText Component:</Text>
       <MaskedText mask="99/99/9999" style={styles.paragraph}>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "prepare": "bob build",
     "release": "dotenv release-it --"
   },
+  "dependencies": {
+    "bignumber.js": "^9.0.1"
+  },
   "devDependencies": {
     "@release-it/conventional-changelog": "^2.0.1",
     "@types/react-native": "^0.64.5",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "expo",
     "text-input"
   ],
-  "main": "lib/commonjs/index.js",
-  "module": "lib/module/index.js",
-  "react-native": "lib/module/index.js",
-  "source": "lib/module/index.js",
+  "main": "lib/commonjs/index",
+  "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",
+  "react-native": "lib/commonjs/index",
+  "source": "src/index",
   "files": [
     "lib/"
   ],
@@ -47,8 +47,9 @@
     "babel-jest": "^27.0.2",
     "dotenv-cli": "^4.0.0",
     "jest": "^27.0.4",
-    "react": "*",
-    "react-native": "*",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-native": "0.64.2",
     "react-native-builder-bob": "^0.18.1",
     "react-test-renderer": "^17.0.2",
     "release-it": "^14.6.2",

--- a/src/@types/MaskOptions.ts
+++ b/src/@types/MaskOptions.ts
@@ -1,0 +1,11 @@
+export interface MaskOptions {
+  prefix?: string
+  decimalSeparator?: string,
+  groupSeparator?: string,
+  precision?: number,
+  groupSize?: number,
+  secondaryGroupSize?: number,
+  fractionGroupSeparator?: string,
+  fractionGroupSize?: number,
+  suffix?: string
+}

--- a/src/components/MaskedText.test.tsx
+++ b/src/components/MaskedText.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render } from '@testing-library/react-native';
 import { MaskedText } from './MaskedText';
 

--- a/src/components/MaskedText.test.tsx
+++ b/src/components/MaskedText.test.tsx
@@ -2,10 +2,25 @@ import { render } from '@testing-library/react-native';
 import { MaskedText } from './MaskedText';
 
 describe('<MaskedText />', () => {
-  test('should renders correctly', () => {
+  test('should renders correctly with custom mask', () => {
     const container = render(<MaskedText mask="AAA-999">RCT777</MaskedText>);
 
     expect(container.getByText('RCT-777')).toBeTruthy();
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should renders correctly with currency mask', () => {
+    const container = render(
+      <MaskedText type="currency" options={{
+        prefix: '$',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        precision: 2
+      }}>5999</MaskedText>
+    );
+
+    expect(container.getByText('$59.99')).toBeTruthy();
 
     expect(container).toMatchSnapshot();
   });

--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -5,12 +5,16 @@ import { mask } from "../utils/mask";
 interface MaskedTextProps {
   children: string;
   mask: string;
+  type?: "custom" | "currency";
+  options?: any;
 }
 
 export function MaskedText({
   children: text,
   mask: pattern,
+  type = "custom",
+  options = {},
   ...rest
 }: MaskedTextProps & TextProps) {
-  return <Text {...rest}>{mask(text, pattern)}</Text>;
+  return <Text {...rest}>{mask(text, pattern, type, options)}</Text>;
 }

--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Text, TextProps } from "react-native";
 import { mask } from "../utils/mask";
 import type { MaskOptions } from "../@types/MaskOptions";

--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -3,14 +3,14 @@ import { mask } from "../utils/mask";
 
 interface MaskedTextProps {
   children: string;
-  mask: string;
+  mask?: string;
   type?: "custom" | "currency";
   options?: any;
 }
 
 export function MaskedText({
   children: text,
-  mask: pattern,
+  mask: pattern = "",
   type = "custom",
   options = {},
   ...rest

--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -1,18 +1,19 @@
 import { Text, TextProps } from "react-native";
 import { mask } from "../utils/mask";
+import type { MaskOptions } from "../@types/MaskOptions";
 
 interface MaskedTextProps {
   children: string;
   mask?: string;
   type?: "custom" | "currency";
-  options?: any;
+  options?: MaskOptions;
 }
 
 export function MaskedText({
   children: text,
   mask: pattern = "",
   type = "custom",
-  options = {},
+  options = {} as MaskOptions,
   ...rest
 }: MaskedTextProps & TextProps) {
   return <Text {...rest}>{mask(text, pattern, type, options)}</Text>;

--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { MaskedTextInput } from './MaskedTextInput';
 

--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -4,12 +4,24 @@ import { MaskedTextInput } from './MaskedTextInput';
 describe('<MaskedTextInput />', () => {
   const mockedOnChangeText = jest.fn();
 
-  test('should renders correctly', () => {
+  test('should renders correctly with custom mask', () => {
     const container = render(<MaskedTextInput mask="AAA-999" onChangeText={mockedOnChangeText} />);
     expect(container).toMatchSnapshot();
   });
 
-  test('should mask input text', async () => {
+  test('should renders correctly with custom mask', () => {
+    const container = render(
+      <MaskedTextInput type="currency" options={{
+        prefix: '$',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        precision: 2
+      }} onChangeText={mockedOnChangeText} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should mask input text with custom mask', async () => {
     const container = render(
       <MaskedTextInput mask="AAA-999" onChangeText={mockedOnChangeText} testID="masked-text-input"/>
     );
@@ -17,8 +29,24 @@ describe('<MaskedTextInput />', () => {
     fireEvent.changeText(container.getByTestId("masked-text-input"), 'RCT777')
 
     await waitFor(() => {
-      expect(mockedOnChangeText).toHaveBeenCalledTimes(3);
       expect(container.getByDisplayValue("RCT-777")).toBeTruthy();
+    })
+  });
+
+  test('should mask input text with currency mask', async () => {
+    const container = render(
+      <MaskedTextInput type="currency" options={{
+        prefix: '$',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+        precision: 2
+      }} onChangeText={mockedOnChangeText} testID="masked-text-input"/>
+    );
+
+    fireEvent.changeText(container.getByTestId("masked-text-input"), '5999')
+
+    await waitFor(() => {
+      expect(container.getByDisplayValue("$59.99")).toBeTruthy();
     })
   });
 })

--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -10,7 +10,7 @@ describe('<MaskedTextInput />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('should renders correctly with custom mask', () => {
+  test('should renders correctly with currency mask', () => {
     const container = render(
       <MaskedTextInput type="currency" options={{
         prefix: '$',

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { TextInput, TextInputProps } from "react-native";
 import { mask, unMask } from "../utils/mask";
 import type { MaskOptions } from "../@types/MaskOptions";

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -1,20 +1,21 @@
 import { useEffect, useState } from "react";
 import { TextInput, TextInputProps } from "react-native";
 import { mask, unMask } from "../utils/mask";
+import type { MaskOptions } from "../@types/MaskOptions";
 
 type TIProps = Omit<TextInputProps, "onChangeText">;
 
 interface MaskedTextInputProps extends TIProps {
   mask?: string;
   type?: "custom" | "currency";
-  options?: any;
+  options?: MaskOptions;
   onChangeText: (text: string, rawText: string) => void;
 }
 
 export function MaskedTextInput({
   mask: pattern = "",
   type = "custom",
-  options = {},
+  options = {} as MaskOptions,
   onChangeText,
   ...rest
 }: MaskedTextInputProps) {

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -5,23 +5,31 @@ import { mask, unMask } from "../utils/mask";
 type TIProps = Omit<TextInputProps, "onChangeText">;
 
 interface MaskedTextInputProps extends TIProps {
-  mask: string;
+  mask?: string;
+  type?: "custom" | "currency";
+  options?: any;
   onChangeText: (text: string, rawText: string) => void;
 }
 
 export function MaskedTextInput({
-  mask: pattern,
+  mask: pattern = "",
+  type = "custom",
+  options = {},
   onChangeText,
   ...rest
 }: MaskedTextInputProps) {
-  const [maskedValue, setMaskedValue] = useState("");
-  const [unMaskedValue, setUnmaskedValue] = useState("");
+  const initialMaskedValue = type === "currency" ? mask("0", pattern, type, options) : ""
+  const initialUnMaskedValue = type === "currency" ? "0" : ""
+
+  const [maskedValue, setMaskedValue] = useState(initialMaskedValue);
+  const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue);
 
   function onChange(value: string) {
-    const newMaskedValue = mask(value, pattern);
+    const newUnMaskedValue = unMask(value, type);
+    const newMaskedValue = mask(newUnMaskedValue, pattern, type, options);
 
     setMaskedValue(newMaskedValue);
-    setUnmaskedValue(unMask(newMaskedValue));
+    setUnmaskedValue(newUnMaskedValue);
   }
 
   useEffect(() => {

--- a/src/components/__snapshots__/MaskedText.test.tsx.snap
+++ b/src/components/__snapshots__/MaskedText.test.tsx.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MaskedText /> should renders correctly 1`] = `
+exports[`<MaskedText /> should renders correctly with currency mask 1`] = `
+<Text>
+  $59.99
+</Text>
+`;
+
+exports[`<MaskedText /> should renders correctly with custom mask 1`] = `
 <Text>
   RCT-777
 </Text>

--- a/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
+++ b/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<MaskedTextInput /> should renders correctly with currency mask 1`] = `
+<TextInput
+  allowFontScaling={true}
+  onChangeText={[Function]}
+  rejectResponderTermination={true}
+  underlineColorAndroid="transparent"
+  value="$0.00"
+/>
+`;
+
 exports[`<MaskedTextInput /> should renders correctly with custom mask 1`] = `
 <TextInput
   allowFontScaling={true}
@@ -7,15 +17,5 @@ exports[`<MaskedTextInput /> should renders correctly with custom mask 1`] = `
   rejectResponderTermination={true}
   underlineColorAndroid="transparent"
   value=""
-/>
-`;
-
-exports[`<MaskedTextInput /> should renders correctly with custom mask 2`] = `
-<TextInput
-  allowFontScaling={true}
-  onChangeText={[Function]}
-  rejectResponderTermination={true}
-  underlineColorAndroid="transparent"
-  value="$0.00"
 />
 `;

--- a/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
+++ b/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
@@ -1,11 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MaskedTextInput /> should renders correctly 1`] = `
+exports[`<MaskedTextInput /> should renders correctly with custom mask 1`] = `
 <TextInput
   allowFontScaling={true}
   onChangeText={[Function]}
   rejectResponderTermination={true}
   underlineColorAndroid="transparent"
   value=""
+/>
+`;
+
+exports[`<MaskedTextInput /> should renders correctly with custom mask 2`] = `
+<TextInput
+  allowFontScaling={true}
+  onChangeText={[Function]}
+  rejectResponderTermination={true}
+  underlineColorAndroid="transparent"
+  value="$0.00"
 />
 `;

--- a/src/utils/mask.test.ts
+++ b/src/utils/mask.test.ts
@@ -14,9 +14,21 @@ test('should mask with alpha pattern', () => {
   expect(received).toBe(expected)
 })
 
-test('should mask with alphanum pattern', () => {
+test('should mask with alphanumeric pattern', () => {
   const expected = 'rct-777'
   const received = mask('rct 777', 'AAA-999')
+
+  expect(received).toBe(expected)
+})
+
+test('should mask with currency mask', () => {
+  const expected = '$59.99'
+  const received = mask('5999', '', 'currency', {
+    prefix: '$',
+    decimalSeparator: '.',
+    groupSeparator: ',',
+    precision: 2
+  })
 
   expect(received).toBe(expected)
 })
@@ -24,6 +36,13 @@ test('should mask with alphanum pattern', () => {
 test('should unMask text', () => {
   const expected = '34293448080'
   const received = unMask('342.934.480-80')
+
+  expect(received).toBe(expected)
+})
+
+test('should unMask currency', () => {
+  const expected = '5999'
+  const received = unMask('$59.99', 'currency')
 
   expect(received).toBe(expected)
 })

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -1,12 +1,26 @@
 /* eslint-disable no-confusing-arrow */
+import { BigNumber } from "bignumber.js";
 import toPattern from "./toPattern";
 
 /**
  * function unMask(
  * @param {string} value
+ * @param {'custom' | 'currency'} type
  * @returns {string}
  */
-function unMask(value: string) {
+function unMask(
+  value: string,   
+  type: "custom" | "currency" = "custom",
+) {
+  if(type === 'currency') {
+    if(!value) return "0";
+
+    const unMaskedValue = value.replace(/\D/g,'');
+    const number = parseInt(unMaskedValue.trimStart());
+
+    return number.toString();
+  }
+  
   return value.replace(/\W/g, "");
 }
 
@@ -19,6 +33,46 @@ function unMask(value: string) {
  */
 function masker(value: string, pattern: string, options: any) {
   return toPattern(value, { pattern, ...options });
+}
+
+/**
+ * function masker(
+ * @param {string} value
+ * @param {any} options
+ * @returns {string}
+ */
+function currencyMasker(value: string = "0", options: any) {
+  const { 
+    prefix,
+    decimalSeparator,
+    groupSeparator,
+    precision,
+    groupSize,
+    secondaryGroupSize,
+    fractionGroupSeparator,
+    fractionGroupSize,
+    suffix
+  } = options;
+
+  const precisionDivider = parseInt(1 + "0".repeat(precision ||0))
+  const number = parseInt(value) / precisionDivider;
+
+  const formatter = {
+    prefix,
+    decimalSeparator,
+    groupSeparator,
+    groupSize: groupSize || 3,
+    secondaryGroupSize,
+    fractionGroupSeparator,
+    fractionGroupSize,
+    suffix
+  }
+  
+  const bigNumber = new BigNumber(number)
+  
+  BigNumber.config({ FORMAT: formatter })
+  
+  return bigNumber.toFormat(precision)
 }
 
 /**
@@ -45,19 +99,25 @@ function multimasker(value: string, patterns: string[], options: any) {
  * function mask(
  * @param {string} value
  * @param {string | string[]} patterns
+ * @param {'custom' | 'currency'} type
  * @param {any} options
  * @returns {string}
  */
 function mask(
   value: string | number,
-  pattern: string | string[],
+  pattern: string | string[] = "",
+  type: "custom" | "currency" = "custom",
   options?: any
 ) {
-  if (typeof pattern === "string") {
-    return masker(String(value), pattern || "", options);
+  if (type === "currency") {
+    return currencyMasker(String(value), options);
   }
 
-  return multimasker(String(value), pattern, options);
+  if (typeof pattern === "string") {
+    return masker(String(value), pattern || "", {});
+  }
+
+  return multimasker(String(value), pattern, {});
 }
 
 export { mask, unMask };

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -54,7 +54,7 @@ function currencyMasker(value: string = "0", options: any) {
     suffix
   } = options;
 
-  const precisionDivider = parseInt(1 + "0".repeat(precision ||0))
+  const precisionDivider = parseInt(1 + "0".repeat(precision || 0))
   const number = parseInt(value) / precisionDivider;
 
   const formatter = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
# Overview
This Pull Request has the objective of close #4 

The next steps are to create tests for most features possible and merge them with this PR to prevent bugs.

Before releasing this feature, we need to refactor the types (currently made with annotations) inside utils.
Also, we need to add types options object from currency format because are not typed yet.

After all, we need to add usage on README.md

# TODO

- [X] Implementation on functions
- [X] Implementation on components
- [x] Add tests
- [x] Add Types
- [x] Add examples
- [x] Add usage to README.md

# Test Plan

## MaskextTextInput
```jsx
<MaskedTextInput
  type="currency"
  options={{
    prefix: "R$",
    decimalSeparator: ',',
    groupSeparator: '.',
    precision: 2,
  }}
  onChangeText={(text, rawText) => {
    setMaskedValue(text);
    setUnmaskedValue(rawText);
  }}
  style={styles.input}
  keyboardType="numeric"
/>
```

## MaskedText
```jsx
<MaskedText
  type="currency"
  options={{
    prefix: "R$",
    decimalSeparator: ',',
    groupSeparator: '.',
    precision: 2,
  }}
>
  5999
</MaskedText>
```

## mask function
```js
mask("5999", null, "currency", {
  prefix: "R$",
  decimalSeparator: ',',
  groupSeparator: '.',
  precision: 3,
})
```

## unMask function
```js
unMask("5999", "currency")
```

