### PR TITLE
Add option types and static type checking

### DIFF
--- a/src/@types/OptionPatterns.ts
+++ b/src/@types/OptionPatterns.ts
@@ -1,0 +1,46 @@
+export type OptionPattern = {
+  pattern: string;
+  placeholder: string;
+};
+
+export function instanceOfOptionPattern(object: any): object is OptionPattern {
+  return (
+    "pattern" in object &&
+    typeof object["pattern"] === "string" &&
+    "placeholder" in object &&
+    typeof object["placeholder"] === "string"
+  );
+}
+
+export type CurrencyMaskOptionPattern = {
+  prefix?: string;
+  decimalSeparator?: string;
+  groupSeparator?: string;
+  groupSize?: number;
+  secondaryGroupSize?: number;
+  fractionGroupSeparator?: string;
+  fractionGroupSize?: number;
+  suffix?: string;
+  precision?: number;
+};
+
+export function instanceOfCurrencyMaskOptionPattern(
+  object: any
+): object is CurrencyMaskOptionPattern {
+  return (
+    ("prefix" in object && typeof object["prefix"] === "string") ||
+    ("decimalSeparator" in object &&
+      typeof object["decimalSeparator"] === "string") ||
+    ("groupSeparator" in object &&
+      typeof object["groupSeparator"] === "string") ||
+    ("groupSize" in object && typeof object["groupSize"] === "number") ||
+    ("secondaryGroupSize" in object &&
+      typeof object["secondaryGroupSize"] === "number") ||
+    ("fractionGroupSeparator" in object &&
+      typeof object["fractionGroupSeparator"] === "string") ||
+    ("fractionGroupSize" in object &&
+      typeof object["fractionGroupSize"] === "number") ||
+    ("suffix" in object && typeof object["suffix"] === "string") ||
+    ("precision" in object && typeof object["precision"] === "number")
+  );
+}

--- a/src/utils/addPlaceholder.ts
+++ b/src/utils/addPlaceholder.ts
@@ -1,12 +1,5 @@
 import { DIGIT, ALPHA, ALPHANUM } from "./constants.json";
 
-/**
- * function addPlaceholder
- * @param {string[]} output
- * @param {number} index
- * @param {string} placeholder
- * @returns {string[]}
- */
 function addPlaceholder(
   output: string[],
   index: number,

--- a/src/utils/toPattern.ts
+++ b/src/utils/toPattern.ts
@@ -1,17 +1,7 @@
 import { DIGIT, ALPHA, ALPHANUM } from "./constants.json";
 import addPlaceholder from "./addPlaceholder";
+import type { OptionPattern } from "src/@types/OptionPatterns";
 
-type OptionPattern = {
-  pattern: string;
-  placeholder: string;
-};
-
-/**
- * function toPattern
- * @param {number | string} value
- * @param {string | OptionPattern} optionPattern
- * @returns {string}
- */
 function toPattern(
   value: number | string,
   optionPattern: string | OptionPattern


### PR DESCRIPTION
# Overview

- Typed Option Objects passed to mask methods (already existed OptionPattern type - used as base).
  - OptionPattern (custom patterns):
       ```typescript
          type OptionPattern = {
            pattern: string;
            placeholder: string;
          };
       ```
  - CurrencyMaskOptionPattern:
       ```typescript
           type CurrencyMaskOptionPattern = {
             prefix?: string;
             decimalSeparator?: string;
             groupSeparator?: string;
             groupSize?: number;
             secondaryGroupSize?: number;
             fractionGroupSeparator?: string;
             fractionGroupSize?: number;
             suffix?: string;
             precision?: number;
           };
       ```

- Removed annotations (as suggested by @akinncar).
- Typed some methods' return types that was not typed before.
- Added static type checking for the types created (mentioned above).
- Use these checks to validate option types inside ```mask``` method, as follows:

```typescript
  if (type === "currency") {
    if (instanceOfCurrencyMaskOptionPattern(options)) {
      return currencyMasker(String(value), options);
    }
    throw "Option Schema not allowed";
  }

  if (typeof pattern === "string") {
    if (instanceOfOptionPattern(options)) {
      return masker(String(value), pattern || "", options);
    }
    throw "Option Schema not allowed";
  }
```

Build still works just fine.