### PR TITLE
fix: MaskedTextInput default value don't work

### DIFF
--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -10,6 +10,13 @@ describe('<MaskedTextInput />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('should renders correctly with custom mask default value', () => {
+    const container = render(
+      <MaskedTextInput mask="AAA-999" onChangeText={mockedOnChangeText} defaultValue="ABC-123" />
+    );
+    expect(container.getByDisplayValue("ABC-123")).toBeTruthy();
+  });
+
   test('should renders correctly with currency mask', () => {
     const container = render(
       <MaskedTextInput type="currency" options={{

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -14,6 +14,7 @@ interface MaskedTextInputProps extends TIProps {
   mask?: string;
   type?: "custom" | "currency";
   options?: MaskOptions;
+  defaultValue?: string;
   onChangeText: (text: string, rawText: string) => void;
 }
 
@@ -25,14 +26,24 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
     mask: pattern = "",
     type = "custom",
     options = {} as MaskOptions,
+    defaultValue,
     onChangeText,
     ...rest
   },
   ref
 ) => {
-  const initialMaskedValue =
-    type === "currency" ? mask("0", pattern, type, options) : "";
-  const initialUnMaskedValue = type === "currency" ? "0" : "";
+  const defaultValueCustom = defaultValue || "";
+  const defaultValueCurrency = defaultValue || "0";
+
+  const initialMaskedValue = 
+    type === "currency" 
+      ? mask(defaultValueCurrency, pattern, type, options) 
+      : mask(defaultValueCustom, pattern, type, options);
+
+  const initialUnMaskedValue =
+    type === "currency" 
+      ? unMask(defaultValueCurrency, type)
+      : unMask(defaultValueCustom, type);
 
   const [maskedValue, setMaskedValue] = useState(initialMaskedValue);
   const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue);


### PR DESCRIPTION
# Overview
Closes #23 


# Test Plan
```jsx
<MaskedTextInput
  mask="999-999-999"
  defaultValue="012-345-678"
  onChangeText={(value, rawValue) => console.log({ value, rawValue })}
  placeholder="000-000-000"
/>
```
and
```jsx
<MaskedTextInput
  mask="999-999-999"
  defaultValue="012345678"
  onChangeText={(value, rawValue) => console.log({ value, rawValue })}
  placeholder="000-000-000"
/>
```
