### PR TITLE
Exporting MaskedTextProps & MaskedTextInputProps types

### DIFF
--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -3,7 +3,7 @@ import { Text, TextProps } from 'react-native'
 import { mask } from '../utils/mask'
 import type { MaskOptions } from '../@types/MaskOptions'
 
-interface MaskedTextProps {
+export interface MaskedTextProps {
   children: string
   mask?: string
   type?: 'custom' | 'currency'

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -10,7 +10,7 @@ import type { MaskOptions } from '../@types/MaskOptions'
 
 type TIProps = Omit<TextInputProps, 'onChangeText'>
 
-interface MaskedTextInputProps extends TIProps {
+export interface MaskedTextInputProps extends TIProps {
   mask?: string
   type?: 'custom' | 'currency'
   options?: MaskOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-import { MaskedText } from './components/MaskedText'
-import { MaskedTextInput } from './components/MaskedTextInput'
+import { MaskedText, MaskedTextProps } from './components/MaskedText'
+import { MaskedTextInput, MaskedTextInputProps } from './components/MaskedTextInput'
 
 import { mask, unMask } from './utils/mask'
 
 export { MaskedText, MaskedTextInput, mask, unMask }
+
+export type { MaskedTextProps, MaskedTextInputProps }


### PR DESCRIPTION
# Overview
Exposing MaskedTextProps & MaskedTextInputProps from the package


# Test Plan
Try importing MaskedTextProps & MaskedTextInputProps from the package:
`import {  MaskedTextInputProps, MaskedTextProps } from "react-native-mask-text"`