### PR TITLE
docs: creating a snack with sign up example page

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const code = unMask("ABC-1234") // return ABC1234
 
 You can see an example app with Expo CLI [here](example/App.js).
 
-You can see a SignUp example working with iOS, Mobile, and Web [here](https://snack.expo.dev/@brenont/react-native-mask-text-example).
+You can see a SignUp example on Expo Snack working with iOS, Mobile, and Web [here](https://snack.expo.dev/@brenont/react-native-mask-text-example).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ const code = unMask("ABC-1234") // return ABC1234
 
 You can see an example app with Expo CLI [here](example/App.js).
 
+You can see a SignUp example working with iOS, Mobile, and Web [here](https://snack.expo.dev/@brenont/react-native-mask-text-example).
+
 ## Contributing
 
 See [Contributing.md](Contributing.md)


### PR DESCRIPTION
# Overview
I created an expo-snack using react-native-mask-text to create a sign-up page. In the example, I use the library to create birth-day and currency inputs.

I'm solving this issue: https://github.com/akinncar/react-native-mask-text/issues/5

# Test Plan
Please check it out and let me know what I can improve.
https://snack.expo.dev/@brenont/react-native-mask-text-example