### PR TITLE
fix: npm ignore tests and snapshots

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@ lib/**/*.test.js
 lib/**/*.test.js.map
 lib/**/*.test.d.ts
 **/__snapshots__/**
-

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
 src/
+lib/**/*.test.js
+lib/**/*.test.js.map
+lib/**/*.test.d.ts
+**/__snapshots__/**
+


### PR DESCRIPTION
# Overview
It is not reducing build size but is reducing the size on npm.
Closes #29 

# Test Plan
