### PR TITLE
Correctly set 'value' prop

### DIFF
--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -61,9 +61,9 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
   return (
     <TextInput
       onChangeText={(value) => onChange(value)}
-      value={maskedValue}
       ref={ref}
       {...rest}
+      value={maskedValue}
     />
   );
 };


### PR DESCRIPTION
# Overview
User might set `value` prop unintentionally and this shouldn't break the component.

This doesn't work as expected without the change:
```js
      <MaskedTextInput
        mask="99/99/9999"
        onChangeText={(text, rawText) => {
          setMaskedValue(text)
          setUnmaskedValue(rawText)
        }}
        style={styles.input}
        keyboardType="numeric"
        value={undefined}                // <== this brakes masking
      />
```