### PR TITLE
Simplify and optimize defaultValue logic

### DIFF
--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -26,25 +26,17 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
     mask: pattern = '',
     type = 'custom',
     options = {} as MaskOptions,
-    defaultValue,
+    defaultValue: defaultValueProp,
     onChangeText,
     ...rest
   },
   ref
 ): JSX.Element => {
-  const defaultValueCustom = defaultValue || ''
-  const defaultValueCurrency = defaultValue || '0'
+  
+  const defaultValue = defaultValueProp || (type === 'currency' ? '0' : '')
 
-  const initialMaskedValue =    type === 'currency'
-      ? mask(defaultValueCurrency, pattern, type, options)
-      : mask(defaultValueCustom, pattern, type, options);
-
-  const initialUnMaskedValue =    type === 'currency'
-      ? unMask(defaultValueCurrency, type)
-      : unMask(defaultValueCustom, type);
-
-  const [maskedValue, setMaskedValue] = useState(initialMaskedValue);
-  const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue);
+  const [maskedValue, setMaskedValue] = useState(() => mask(defaultValue, pattern, type, options));
+  const [unMaskedValue, setUnmaskedValue] = useState(() => unMask(defaultValue, type));
 
   function onChange(value: string) {
     const newUnMaskedValue = unMask(value, type);


### PR DESCRIPTION
# Overview
It just simplifies the logic and also optimize it by setting the initialValue of useState inside a function so it isn't unnecessarily calculated at every render


# Test Plan
None

I will leave it as a draft until further testing, but apparently should be working as same.