### PR TITLE
fix: watching value prop and updating state to fix controlled input

### DIFF
--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -28,20 +28,20 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
     options = {} as MaskOptions,
     defaultValue,
     onChangeText,
+    value,
     ...rest
   },
   ref
 ): JSX.Element => {
+  const getMaskedValue = (value: string) => mask(value, pattern, type, options);
+  const getUnMaskedValue = (value: string) => unMask(value, type);
+
   const defaultValueCustom = defaultValue || ''
   const defaultValueCurrency = defaultValue || '0'
 
-  const initialMaskedValue =    type === 'currency'
-      ? mask(defaultValueCurrency, pattern, type, options)
-      : mask(defaultValueCustom, pattern, type, options);
+  const initialMaskedValue = getMaskedValue(type === 'currency' ? defaultValueCurrency : defaultValueCustom);
 
-  const initialUnMaskedValue =    type === 'currency'
-      ? unMask(defaultValueCurrency, type)
-      : unMask(defaultValueCustom, type);
+  const initialUnMaskedValue = getUnMaskedValue(type === 'currency' ? defaultValueCurrency : defaultValueCustom);
 
   const [maskedValue, setMaskedValue] = useState(initialMaskedValue);
   const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue);
@@ -57,6 +57,16 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
   useEffect(() => {
     onChangeText(maskedValue, unMaskedValue);
   }, [maskedValue, unMaskedValue]);
+
+  useEffect(() => {
+    if (value) {
+      setMaskedValue(getMaskedValue(value));
+      setUnmaskedValue(getUnMaskedValue(value));
+    } else {
+      setMaskedValue(initialMaskedValue);
+      setUnmaskedValue(initialUnMaskedValue);
+    }
+  }, [value])
 
   return (
     <TextInput


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixing issue: https://github.com/akinncar/react-native-mask-text/issues/51
The value prop was being ignored in the `MaskedTextInput` component. On this PR I'm watching the value prop to once it changes the state of `maskedValue` and `unsmakedValue` should be updated.

With this fixer, we're able to use the input as a controlled input, passing a state as a value. once the state changes the input value will always update.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
1. Use the MaskedTextInput passing a state as a value
2. Change this state in another way, not the input
3. The input value should update

Code example: 
```js
const [input, setInput] = useState<string>('initial value');

const changeInputToWelcome = () => {
  setInput('Welcome!');
}
 
return (
  <>
    <MaskedTextInput value={input} />
    <Button onPress={changeInputToWelcome} />
  </>
)

```
