### PR TITLE
feat: add date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,48 @@ import { MaskedText } from "react-native-mask-text";
 <MaskedText mask="99/99/9999">30081990</MaskedText>;
 ```
 
+## Date Mask
+
+These options only are used if you use prop `type="date"` in your component:
+
+| Option                 | Type   | Mandatory | Default Value | Description                                 |
+|------------------------|--------|-----------|---------------|---------------------------------------------|
+| dateFormat             | string | No        | yyyy/mm/dd    | Date Format                                 |
+
+### Usage MaskedTextInput (date)
+
+Component similar with `<TextInput />` but with date mask option.
+
+```jsx
+import { StyleSheet } from "react-native";
+import { MaskedTextInput } from "react-native-mask-text";
+
+//...
+
+<MaskedTextInput
+  type="date"
+  options={{
+    dateFormat: 'YYYY/DD/MM',
+  }}
+  onChangeText={(text, rawText) => {
+    console.log(text);
+    console.log(rawText);
+  }}
+  style={styles.input}
+  keyboardType="numeric"
+/>
+
+//...
+
+const styles = StyleSheet.create({
+  input: {
+    height: 40,
+    margin: 12,
+    borderWidth: 1,
+  },
+});
+```
+
 ## Currency Mask
 
 These options only are used if you use prop `type="currency"` in your component:

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -13,7 +13,7 @@ export default function App() {
     <View style={styles.container}>
       <Text style={styles.title}>MaskedTextInput Component:</Text>
       <MaskedTextInput
-        mask="99/99/9999"
+        mask="AAA-999"
         onChangeText={(text, rawText) => {
           setMaskedValue(text)
           setUnmaskedValue(rawText)

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -72,6 +72,14 @@ function currencyMasker(value = '0', options: any) {
   return bigNumber.toFormat(precision)
 }
 
+function dateMasker(value = '', options: any) {
+  const { dateFormat = 'yyyy/mm/dd' } = options
+
+  const regex = /[a-zA-Z]/gi
+  const pattern = dateFormat.replaceAll(regex, '9')
+  return masker(value, pattern, {})
+}
+
 /**
  * function multimasker(
  * @param {string} value
@@ -102,11 +110,15 @@ function multimasker(value: string, patterns: string[], options: any) {
 function mask(
   value: string | number,
   pattern: string | string[] = '',
-  type: 'custom' | 'currency' = 'custom',
+  type: 'custom' | 'currency' | 'date' = 'custom',
   options?: any
 ) {
   if (type === 'currency') {
     return currencyMasker(String(value), options)
+  }
+
+  if (type === 'date') {
+    return dateMasker(String(value), options)
   }
 
   if (typeof pattern === 'string') {


### PR DESCRIPTION
# Overview
Add Date format type variation
**Note:** there's no validations
#17 

# Test Plan
```js
<MaskedTextInput
  type="date"
  options={{
    dateFormat: 'YYYY/DD/MM',
  }}
  onChangeText={(text, rawText) => {
    console.log(text);
    console.log(rawText);
  }}
  style={styles.input}
  keyboardType="numeric"
/>
```