### PR TITLE
feat: add 24h time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,48 @@ const styles = StyleSheet.create({
 });
 ```
 
+## Time Mask
+
+These options only are used if you use prop `type="time"` in your component:
+
+| Option                 | Type   | Mandatory | Default Value | Description                                 |
+|------------------------|--------|-----------|---------------|---------------------------------------------|
+| timeFormat             | string | No        | HH:mm:ss      | Time Format                                 |
+
+### Usage MaskedTextInput (time)
+
+Component similar with `<TextInput />` but with time mask option.
+
+```jsx
+import { StyleSheet } from "react-native";
+import { MaskedTextInput } from "react-native-mask-text";
+
+//...
+
+<MaskedTextInput
+  type="time"
+  options={{
+    timeFormat: 'HH:mm:ss', // or 'HH:mm'
+  }}
+  onChangeText={(text, rawText) => {
+    setMaskedValue(text)
+    setUnmaskedValue(rawText)
+  }}
+  style={styles.input}
+  keyboardType="numeric"
+/>
+
+//...
+
+const styles = StyleSheet.create({
+  input: {
+    height: 40,
+    margin: 12,
+    borderWidth: 1,
+  },
+});
+```
+
 ## Currency Mask
 
 These options only are used if you use prop `type="currency"` in your component:

--- a/src/utils/constants.json
+++ b/src/utils/constants.json
@@ -1,5 +1,0 @@
-{
-  "DIGIT": "9",
-  "ALPHA": "A",
-  "ALPHANUM": "S"
-}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,7 @@
-export const DIGIT = "9";
-export const ALPHA = "A";
-export const ALPHANUM = "S";
+export const DIGIT = '9'
+export const ALPHA = 'A'
+export const ALPHANUM = 'S'
+export const HOURS = 'H'
+// export const HOURS_AM_PM = 'h'
+export const MINUTES = 'm'
+export const SECONDS = 's'

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -80,6 +80,13 @@ function dateMasker(value = '', options: any) {
   return masker(value, pattern, {})
 }
 
+function timeMasker(value = '', options: any) {
+  const { timeFormat = 'HH:mm:ss' } = options
+
+  const pattern = timeFormat
+  return masker(value, pattern, {})
+}
+
 /**
  * function multimasker(
  * @param {string} value
@@ -99,26 +106,22 @@ function multimasker(value: string, patterns: string[], options: any) {
   )
 }
 
-/**
- * function mask(
- * @param {string} value
- * @param {string | string[]} patterns
- * @param {'custom' | 'currency'} type
- * @param {any} options
- * @returns {string}
- */
 function mask(
   value: string | number,
   pattern: string | string[] = '',
-  type: 'custom' | 'currency' | 'date' = 'custom',
+  type: 'custom' | 'currency' | 'date' | 'time' = 'custom',
   options?: any
-) {
+): string {
   if (type === 'currency') {
     return currencyMasker(String(value), options)
   }
 
   if (type === 'date') {
     return dateMasker(String(value), options)
+  }
+
+  if (type === 'time') {
+    return timeMasker(String(value), options)
   }
 
   if (typeof pattern === 'string') {

--- a/src/utils/toPattern.ts
+++ b/src/utils/toPattern.ts
@@ -1,4 +1,4 @@
-import { DIGIT, ALPHA, ALPHANUM } from './constants'
+import { DIGIT, ALPHA, ALPHANUM, MINUTES, SECONDS, HOURS } from './constants'
 import addPlaceholder from './addPlaceholder'
 
 type OptionPattern = {
@@ -44,13 +44,20 @@ function toPattern(
     } else if (
       (output[index] === DIGIT && values[charCounter].match(/[0-9]/)) ||
       (output[index] === ALPHA && values[charCounter].match(/[a-zA-Z]/)) ||
-      (output[index] === ALPHANUM && values[charCounter].match(/[0-9a-zA-Z]/))
+      (output[index] === ALPHANUM &&
+        values[charCounter].match(/[0-9a-zA-Z]/)) ||
+      (output[index] === HOURS && values[charCounter].match(/[0-23]/)) ||
+      (output[index] === MINUTES && values[charCounter].match(/[0-59]/)) ||
+      (output[index] === SECONDS && values[charCounter].match(/[0-59]/))
     ) {
       output[index] = values[charCounter++]
     } else if (
       output[index] === DIGIT ||
       output[index] === ALPHA ||
-      output[index] === ALPHANUM
+      output[index] === ALPHANUM ||
+      output[index] === HOURS ||
+      output[index] === MINUTES ||
+      output[index] === SECONDS
     ) {
       if (placeholder !== undefined) {
         return addPlaceholder(output, index, placeholder).join('')


### PR DESCRIPTION
# Overview
Add time hours, minutes and seconds format

# Test Plan
```js
<MaskedTextInput
  type="time"
  options={{
    timeFormat: 'HH:mm:ss', // or 'HH:mm'
  }}
  onChangeText={(text, rawText) => {
    setMaskedValue(text)
    setUnmaskedValue(rawText)
  }}
  style={styles.input}
  keyboardType="numeric"
/>
```

# TODO
- [X] Docs
- [ ] AM/PM format `(hh:mm:ss)`