### PR TITLE
fix: change path for typescript folder on package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "lib/commonjs/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
# Overview
The compiled code was not working with typescript on the latest version because of wrong path on `package.json`.