### PR TITLE
feat: allow usage without a mask

### DIFF
--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -7,6 +7,13 @@ import { Button, Keyboard, InputAccessoryView } from 'react-native';
 describe('<MaskedTextInput />', () => {
   const mockedOnChangeText = jest.fn();
 
+  test('should render correctly without a mask', () => {
+    const container = render(
+      <MaskedTextInput value="churrasco" onChangeText={mockedOnChangeText} />,
+    );
+    expect(container).toMatchSnapshot();
+  })
+
   test('should renders correctly with custom mask', () => {
     const container = render(
       <MaskedTextInput mask="AAA-999" onChangeText={mockedOnChangeText} />,

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -69,6 +69,7 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
 
   const [maskedValue, setMaskedValue] = useState(initialMaskedValue)
   const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue)
+  const actualValue = pattern || type === "currency" ? maskedValue : unMaskedValue;
 
   function onChange(value: string) {
     const newUnMaskedValue = unMask(value, type as 'custom' | 'currency')
@@ -99,7 +100,7 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
         ref={ref}
         maxLength={pattern.length || undefined}
         {...rest}
-        value={maskedValue}
+        value={actualValue}
         style={{...styleSheet} as StyleObj}
       />
       {inputAccessoryView}

--- a/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
+++ b/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<MaskedTextInput /> should render correctly without a mask 1`] = `
+<TextInput
+  allowFontScaling={true}
+  onChangeText={[Function]}
+  rejectResponderTermination={true}
+  style={
+    Object {
+      "fontStyle": undefined,
+      "fontWeight": undefined,
+      "textDecorationLine": undefined,
+    }
+  }
+  underlineColorAndroid="transparent"
+  value="churrasco"
+/>
+`;
+
 exports[`<MaskedTextInput /> should renders correctly with currency mask 1`] = `
 <TextInput
   allowFontScaling={true}


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixes #55;
It makes sense to allow its usage as a normal Input since in component libraries we may or not use a mask and preventing it from working without one would open room for undesired workarounds such as using two components internally based on whether you have or not a mask.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Every spec should keep working as well as the new one added.