### PR TITLE
fix: use raw value instead of unmasked

### DIFF
--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -9,7 +9,7 @@ describe('<MaskedTextInput />', () => {
 
   test('should render correctly without a mask', () => {
     const container = render(
-      <MaskedTextInput value="churrasco" onChangeText={mockedOnChangeText} />,
+      <MaskedTextInput value="with space and special* characters;" onChangeText={mockedOnChangeText} />,
     );
     expect(container).toMatchSnapshot();
   })

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -59,6 +59,8 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
   const defaultValueCustom = defaultValue || ''
   const defaultValueCurrency = defaultValue || '0'
 
+  const initialRawValue = value;
+
   const initialMaskedValue = getMaskedValue(
     type === 'currency' ? defaultValueCurrency : defaultValueCustom
   )
@@ -69,7 +71,8 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
 
   const [maskedValue, setMaskedValue] = useState(initialMaskedValue)
   const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue)
-  const actualValue = pattern || type === "currency" ? maskedValue : unMaskedValue;
+  const [rawValue, setRawValue] = useState(initialRawValue);
+  const actualValue = pattern || type === "currency" ? maskedValue : rawValue;
 
   function onChange(value: string) {
     const newUnMaskedValue = unMask(value, type as 'custom' | 'currency')
@@ -77,6 +80,7 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
 
     setMaskedValue(newMaskedValue)
     setUnmaskedValue(newUnMaskedValue)
+    setRawValue(value);
   }
 
   useEffect(() => {

--- a/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
+++ b/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<MaskedTextInput /> should render correctly without a mask 1`] = `
     }
   }
   underlineColorAndroid="transparent"
-  value="churrasco"
+  value="with space and special* characters;"
 />
 `;
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
In #99 I used `unmaskedValue` when we don't have a mask, but the unmask function is actually a normalization before masking, removing special characters and spacing. I used the pure received value instead in order to prevent it from removing spaces and special characters.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
The updated spec should get this case.