### PR TITLE
Fixed: #175 - Partially compatible with styled components, array of styles doesn't apply styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ You can see a SignUp example on Expo Snack working with iOS, Mobile, and Web [he
 
 ## Contributing
 
-See [Contributing.md](Contributing.md)
+See [Contributing.md](CONTRIBUTING.md)
 
 ## License
 

--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -24,11 +24,14 @@ export function MaskedText({
   style,
   ...rest
 }: MaskedTextProps & TextProps): JSX.Element {
-  const styleSheet = {
-    ...(typeof style === 'object' ? style : {}),
-    fontWeight:textBold ? 'bold' : 'normal',
-    fontStyle: textItalic ? 'italic' : 'normal',
-    textDecorationLine: textDecoration ? textDecoration : 'none'
-  }
-  return <Text {...rest} style={{...styleSheet} as StyleObj}>{mask(text, pattern, type, options)}</Text>;
+  const styleSheet = [
+    {
+      fontWeight: textBold && 'bold',
+      fontStyle: textItalic && 'italic',
+      textDecorationLine: textDecoration
+    },
+    style
+  ]
+  
+  return <Text {...rest} style={styleSheet as StyleObj}>{mask(text, pattern, type, options)}</Text>;
 }

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -45,12 +45,14 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
   },
   ref
 ): JSX.Element => {
-  const styleSheet = {
-    ...(typeof style === 'object' ? style : {}),
-    fontWeight:textBold && 'bold',
-    fontStyle: textItalic && 'italic',
-    textDecorationLine: textDecoration
-  }
+  const styleSheet = [
+    {
+      fontWeight: textBold && 'bold',
+      fontStyle: textItalic && 'italic',
+      textDecorationLine: textDecoration
+    },
+    style
+  ]
   const getMaskedValue = (value: string) =>
     mask(value, pattern, type, options, autoCapitalize)
   const getUnMaskedValue = (value: string) =>
@@ -105,7 +107,7 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
         maxLength={pattern.length || undefined}
         {...rest}
         value={actualValue}
-        style={{...styleSheet} as StyleObj}
+        style={styleSheet as StyleObj}
       />
       {inputAccessoryView}
     </>


### PR DESCRIPTION
# Overview
Fixed #175 
Works fine with arrays of styles 
This changes shouldn't be breaking, you could update a minor version of the package

<img width="525" alt="image" src="https://user-images.githubusercontent.com/32239452/227485675-2862ff36-63e5-47fc-a816-fc7f2477c674.png">

![image](https://user-images.githubusercontent.com/32239452/227485746-67815063-a149-4429-95df-22ac5d1849e2.png)



Also updated REDME.md docs for the correct link to Contributing.md
And update Contributing.md `yarn` in the example app doesn't work there is package.json instead `npm install` works

<img width="1129" alt="Screenshot 2023-03-24 at 11 30 01" src="https://user-images.githubusercontent.com/32239452/227486611-6c51bdb6-9f1d-4746-b193-f7749d414ae4.png">


# Test Plan

I got problems with updating snapshots, @akinncar could you check this PR this, please?

<img width="755" alt="image" src="https://user-images.githubusercontent.com/32239452/227487335-b7eb2812-8d30-47b7-92ba-f19c437e1c3a.png">

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/32239452/227487514-33569b3d-487a-4a5e-ac58-58e1d3b52ba9.png">
