### PR TITLE
Fix autocapitalize prop

### DIFF
--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -17,7 +17,6 @@ export interface MaskedTextInputProps extends TIProps {
   defaultValue?: string
   onChangeText: (text: string, rawText: string) => void
   inputAccessoryView?: JSX.Element
-  autoCapitalize?: 'characters' | 'words' | 'sentences' | 'none'
   textBold?: boolean
   textItalic?:boolean
   textDecoration?:TextDecorationOptions
@@ -105,6 +104,7 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
         onChangeText={(value) => onChange(value)}
         ref={ref}
         maxLength={pattern.length || undefined}
+        autoCapitalize={autoCapitalize}
         {...rest}
         value={actualValue}
         style={styleSheet as StyleObj}

--- a/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
+++ b/src/components/__snapshots__/MaskedTextInput.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<MaskedTextInput /> should render correctly without a mask 1`] = `
 <TextInput
   allowFontScaling={true}
+  autoCapitalize="sentences"
   onChangeText={[Function]}
   rejectResponderTermination={true}
   style={
@@ -23,6 +24,7 @@ exports[`<MaskedTextInput /> should render correctly without a mask 1`] = `
 exports[`<MaskedTextInput /> should renders correctly with currency mask 1`] = `
 <TextInput
   allowFontScaling={true}
+  autoCapitalize="sentences"
   onChangeText={[Function]}
   rejectResponderTermination={true}
   style={
@@ -43,6 +45,7 @@ exports[`<MaskedTextInput /> should renders correctly with currency mask 1`] = `
 exports[`<MaskedTextInput /> should renders correctly with custom mask 1`] = `
 <TextInput
   allowFontScaling={true}
+  autoCapitalize="sentences"
   maxLength={7}
   onChangeText={[Function]}
   rejectResponderTermination={true}


### PR DESCRIPTION
# Overview
The `autoCapitalize` prop was not passed on to the underlying react-native `TextInput` component. This caused the input not be displayed as capitalized.

Also I removed the `autoCapitalize` prop from the `TIProps` type as `TIProps` extends `TextInputProps` which already contains the `autoCapitalize` prop

# Test Plan
Before the fix:
![Screenshot 2023-06-01 at 11 46 54](https://github.com/akinncar/react-native-mask-text/assets/1309448/821f651a-5c9f-471f-b80b-79450a71fb60)

After the fix:
![Screenshot 2023-06-01 at 11 42 17](https://github.com/akinncar/react-native-mask-text/assets/1309448/8d11e1cb-9ca2-49f1-b7a0-d0a8e5397c6d)

