### PR TITLE
fix: prevent the use of onChangeText on the initial render

### DIFF
--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -73,6 +73,8 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
   const [maskedValue, setMaskedValue] = useState(initialMaskedValue)
   const [unMaskedValue, setUnmaskedValue] = useState(initialUnMaskedValue)
   const [rawValue, setRawValue] = useState(initialRawValue);
+  const [isInitialRender, setIsInitialRender] = useState(true)
+
   const actualValue = pattern || type === "currency" ? maskedValue : rawValue;
 
   function onChange(value: string) {
@@ -85,6 +87,11 @@ export const MaskedTextInputComponent: ForwardRefRenderFunction<
   }
 
   useEffect(() => {
+    if (isInitialRender) {
+      setIsInitialRender(false)
+      return
+    }
+
     onChangeText(maskedValue, unMaskedValue)
   }, [maskedValue, unMaskedValue])
 


### PR DESCRIPTION
# Overview
In this PR I add one state for prevent call onChangeText when the component render in the first time!
With this prevent unnecessary validation when i use frameworks  like for exemple react hook form, formik...


# Test Plan
I ran the tests and all on ok
For execute it's necessary only just see if the behavior of the example is maintained without call onChangeText soon as render.

congratulations on the project 😄 !