### PR TITLE
Feat/chanhing const DIGITS to 'D'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ yarn add react-native-mask-text
 
 Pattern used in masked components:
 
-- `9` - accept digit.
+- `D` - accept digit.
 - `A` - accept alpha.
 - `S` - accept alphanumeric.
 
-Ex: AAA-9999
+Ex: AAA-DDDD
 
 ### Usage MaskedTextInput (custom)
 
@@ -33,7 +33,7 @@ import { MaskedTextInput } from "react-native-mask-text";
 //...
 
 <MaskedTextInput
-  mask="AAA-9999"
+  mask="AAA-DDDD"
   onChangeText={(text, rawText) => {
     console.log(text);
     console.log(rawText);
@@ -61,7 +61,7 @@ import { MaskedText } from "react-native-mask-text";
 
 //...
 
-<MaskedText mask="99/99/9999">30081990</MaskedText>;
+<MaskedText mask="DD/DD/DDDD">30081990</MaskedText>;
 ```
 
 ## Date Mask
@@ -230,7 +230,7 @@ Function used to mask text.
 ```js
 import { mask } from "react-native-mask-text";
 
-const code = mask("ABC1234","AAA-9999") // return ABC-1234
+const code = mask("ABC1234","AAA-DDDD") // return ABC-1234
 ```
 
 ## Usage `unMask` function

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export const DIGIT = '9'
+export const DIGIT = 'D'
 export const ALPHA = 'A'
 export const ALPHANUM = 'S'
 export const HOURS = 'H'

--- a/src/utils/mask.test.ts
+++ b/src/utils/mask.test.ts
@@ -2,7 +2,7 @@ import { mask, unMask } from './mask'
 
 test('should mask with number digit pattern', () => {
   const expected = '342.934.480-80'
-  const received = mask('34293448080', '999.999.999-99')
+  const received = mask('34293448080', 'DDD.DDD.DDD-DD')
 
   expect(received).toBe(expected)
 })
@@ -16,7 +16,7 @@ test('should mask with alpha pattern', () => {
 
 test('should mask with alphanumeric pattern', () => {
   const expected = 'rct-777'
-  const received = mask('rct 777', 'AAA-999')
+  const received = mask('rct 777', 'AAA-DDD')
 
   expect(received).toBe(expected)
 })


### PR DESCRIPTION
# Overview
I came across the fact that if I need a phone mask for India (+91), the library will allow me to enter a different code (for example, +31), because it believes that 9 is any digit.  By changing the DIGITS constant to 'D', we will be able to hard-set the mask, which will contain any numbers.

I also changed the tests and the readme to match the DIGITS = 'D'