### PR TITLE
fix: change absolute import to relative path for @types

### DIFF
--- a/src/components/MaskedText.tsx
+++ b/src/components/MaskedText.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Text, TextProps } from 'react-native'
 import { mask } from '../utils/mask'
-import type { MaskOptions, StyleObj, TextDecorationOptions } from 'src/@types'
+import type { MaskOptions, StyleObj, TextDecorationOptions } from '../@types'
 export interface MaskedTextProps {
   children: string
   mask?: string

--- a/src/components/MaskedTextInput.tsx
+++ b/src/components/MaskedTextInput.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react'
 import { TextInput, TextInputProps } from 'react-native'
 import { mask, unMask } from '../utils/mask'
-import type { FormatType, MaskOptions, StyleObj, TextDecorationOptions } from 'src/@types'
+import type { FormatType, MaskOptions, StyleObj, TextDecorationOptions } from '../@types'
 
 
 type TIProps = Omit<TextInputProps, 'onChangeText'>

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-confusing-arrow */
 import { BigNumber } from 'bignumber.js'
-import type { AutoCapitalizeOptions } from 'src/@types/AutoCapitalizeOptions'
+import type { AutoCapitalizeOptions } from '../@types/AutoCapitalizeOptions'
 import type { FormatType } from '../@types/FormatType'
 import toPattern from './toPattern'
 


### PR DESCRIPTION
# Overview
Fixes #321 

**Motivation:**
Currently, the generated TypeScript definition files (`.d.ts`) use absolute import paths pointing to `src/@types`. When a consuming project also has a `src/@types` directory at its root, TypeScript mistakenly resolves the library's imports to the consumer's local folder instead of the library's internal types. This causes exported types like `FormatType`, `MaskOptions`, etc., to silently default to `any`, breaking type safety.

**Change:**
This PR replaces the absolute import (`src/@types`) with a relative import (`../@types`) inside the source components to prevent this path resolution conflict.

# Test Plan
To verify this change and ensure the quality standards of the library:

1. **Tests:** Ran `yarn test` to ensure no existing tests were broken. All tests passed successfully.
2. **Build:** Ran `yarn && yarn prepare` to verify the build and minify process. I confirmed that the newly generated `.d.ts` inside the `lib/typescript/src/components` folder now correctly outputs the relative paths.
3. **Real-world validation:** Before opening this PR, I validated this exact change in a production environment using `patch-package`, which successfully restored type inference and autocomplete in the consuming app.