### PR TITLE
test: expand coverage for mask utils and MaskedTextInput

### DIFF
--- a/src/components/MaskedTextInput.test.tsx
+++ b/src/components/MaskedTextInput.test.tsx
@@ -146,12 +146,102 @@ describe('<MaskedTextInput />', () => {
     expect(tree[0].props.inputAccessoryViewID).toBe('Done');
     expect(tree[1].props.nativeID).toBe('Done');
   });
+  test('should update the masked value when the controlled value prop changes', async () => {
+    const container = render(
+      <MaskedTextInput
+        mask="AAA-999"
+        onChangeText={mockedOnChangeText}
+        value="RCT777"
+      />
+    );
+
+    expect(container.getByDisplayValue('RCT-777')).toBeTruthy()
+
+    container.rerender(
+      <MaskedTextInput
+        mask="AAA-999"
+        onChangeText={mockedOnChangeText}
+        value="ABC123"
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.getByDisplayValue('ABC-123')).toBeTruthy()
+    })
+  });
+
+  test('should reset to the masked default value when the controlled value is cleared', async () => {
+    const container = render(
+      <MaskedTextInput
+        mask="AAA-999"
+        onChangeText={mockedOnChangeText}
+        defaultValue="ABC-123"
+        value="RCT777"
+      />
+    );
+
+    expect(container.getByDisplayValue('RCT-777')).toBeTruthy()
+
+    container.rerender(
+      <MaskedTextInput
+        mask="AAA-999"
+        onChangeText={mockedOnChangeText}
+        defaultValue="ABC-123"
+        value=""
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.getByDisplayValue('ABC-123')).toBeTruthy()
+    })
+  });
+
+  test('should update an unmasked input when the controlled value prop changes', async () => {
+    const container = render(
+      <MaskedTextInput
+        onChangeText={mockedOnChangeText}
+        value="first value"
+      />
+    );
+
+    expect(container.getByDisplayValue('first value')).toBeTruthy()
+
+    container.rerender(
+      <MaskedTextInput
+        onChangeText={mockedOnChangeText}
+        value="second value"
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.getByDisplayValue('second value')).toBeTruthy()
+    })
+  });
+
+  test('should render correctly with a currency default value', () => {
+    const container = render(
+      <MaskedTextInput
+        type="currency"
+        options={{
+          prefix: '$',
+          decimalSeparator: '.',
+          groupSeparator: ',',
+          precision: 2,
+        }}
+        onChangeText={mockedOnChangeText}
+        defaultValue="1099"
+      />
+    );
+
+    expect(container.getByDisplayValue('$10.99')).toBeTruthy()
+  });
+
   test('should be bold when the textBold attribute is added', () => {
     const container  =
-    render(<MaskedTextInput 
-      testID="masked-text-input" 
-      onChangeText={mockedOnChangeText} 
-      textBold 
+    render(<MaskedTextInput
+      testID="masked-text-input"
+      onChangeText={mockedOnChangeText}
+      textBold
       mask="99/99/9999"
       />)
       expect(container.getByTestId('masked-text-input')).toHaveStyle({fontWeight: 'bold' });

--- a/src/utils/mask.test.ts
+++ b/src/utils/mask.test.ts
@@ -33,6 +33,84 @@ test('should mask with currency mask', () => {
   expect(received).toBe(expected)
 })
 
+test('should mask currency with group separator for large numbers', () => {
+  const expected = 'R$ 1.234.567,89'
+  const received = mask('123456789', '', 'currency', {
+    prefix: 'R$ ',
+    decimalSeparator: ',',
+    groupSeparator: '.',
+    precision: 2,
+  })
+
+  expect(received).toBe(expected)
+})
+
+test('should mask currency with a suffix and zero precision', () => {
+  const expected = '1,234 USD'
+  const received = mask('1234', '', 'currency', {
+    groupSeparator: ',',
+    precision: 0,
+    suffix: ' USD',
+  })
+
+  expect(received).toBe(expected)
+})
+
+test('should mask date with the default format', () => {
+  const expected = '2025/01/01'
+  const received = mask('20250101', '', 'date', {})
+
+  expect(received).toBe(expected)
+})
+
+test('should mask date with a custom format', () => {
+  const expected = '01/01/2025'
+  const received = mask('01012025', '', 'date', { dateFormat: 'dd/mm/yyyy' })
+
+  expect(received).toBe(expected)
+})
+
+test('should mask time with the default format', () => {
+  const expected = '12:30:45'
+  const received = mask('123045', '', 'time', {})
+
+  expect(received).toBe(expected)
+})
+
+test('should mask time with a custom format', () => {
+  const expected = '12:34'
+  const received = mask('1234', '', 'time', { timeFormat: 'HH:mm' })
+
+  expect(received).toBe(expected)
+})
+
+test('should pick the shorter pattern for a short value with multiple masks', () => {
+  const expected = '(12) 3456-7890'
+  const received = mask('1234567890', ['(99) 9999-9999', '(99) 99999-9999'])
+
+  expect(received).toBe(expected)
+})
+
+test('should pick the longer pattern for a long value with multiple masks', () => {
+  const expected = '(12) 34567-8901'
+  const received = mask('12345678901', ['(99) 9999-9999', '(99) 99999-9999'])
+
+  expect(received).toBe(expected)
+})
+
+test('should coerce a number value to a string before masking', () => {
+  const expected = '342.934.480-80'
+  const received = mask(34293448080, '999.999.999-99')
+
+  expect(received).toBe(expected)
+})
+
+test('should return an empty string when value and pattern are empty', () => {
+  const received = mask('', '')
+
+  expect(received).toBe('')
+})
+
 test('should unMask text', () => {
   const expected = '34293448080'
   const received = unMask('342.934.480-80')
@@ -43,6 +121,20 @@ test('should unMask text', () => {
 test('should unMask currency', () => {
   const expected = '5999'
   const received = unMask('$59.99', 'currency')
+
+  expect(received).toBe(expected)
+})
+
+test('should unMask an empty currency value to zero', () => {
+  const expected = '0'
+  const received = unMask('', 'currency')
+
+  expect(received).toBe(expected)
+})
+
+test('should default the unMask type to custom', () => {
+  const expected = 'ABC123'
+  const received = unMask('ABC-123')
 
   expect(received).toBe(expected)
 })

--- a/src/utils/toPattern.test.ts
+++ b/src/utils/toPattern.test.ts
@@ -1,0 +1,55 @@
+import toPattern from './toPattern'
+
+test('should format a value that fully fills the pattern', () => {
+  const received = toPattern('34293448080', '999.999.999-99')
+
+  expect(received).toBe('342.934.480-80')
+})
+
+test('should accept a string option pattern', () => {
+  const received = toPattern('123', '999')
+
+  expect(received).toBe('123')
+})
+
+test('should stop at the first unfilled magic character when no placeholder is given', () => {
+  const received = toPattern('342', '999.999.999-99')
+
+  expect(received).toBe('342')
+})
+
+test('should keep literal separators already reached by the input', () => {
+  const received = toPattern('3429', '999.999')
+
+  expect(received).toBe('342.9')
+})
+
+test('should fill remaining magic characters with the placeholder', () => {
+  const received = toPattern('123', { pattern: '999.999', placeholder: '_' })
+
+  expect(received).toBe('123.___')
+})
+
+test('should replace every magic type with the placeholder', () => {
+  const received = toPattern('1', { pattern: '9A-S', placeholder: '*' })
+
+  expect(received).toBe('1*-*')
+})
+
+test('should not append a placeholder when the pattern is completely filled', () => {
+  const received = toPattern('123456', { pattern: '999.999', placeholder: '_' })
+
+  expect(received).toBe('123.456')
+})
+
+test('should return an empty string for an empty value without placeholder', () => {
+  const received = toPattern('', '999.999')
+
+  expect(received).toBe('')
+})
+
+test('should stop at the first input character that does not match the pattern type', () => {
+  const received = toPattern('12ab34', '9999')
+
+  expect(received).toBe('12')
+})


### PR DESCRIPTION
## Summary

Adds tests for a number of code paths that had no coverage. Raises overall statement coverage from **~74% → ~88%**; `MaskedText`, `MaskedTextInput`, and `addPlaceholder` are now at **100%**.

## What's added

**`src/utils/mask.test.ts`**
- `date` type masking (default `yyyy/mm/dd` and custom formats)
- `time` type masking (default `HH:mm:ss` and custom formats)
- multi-mask via pattern array (`multimasker`) — picks the shorter/longer pattern by value length
- currency: group separators for large numbers, suffix + zero precision
- number-value coercion to string, empty value handling
- `unMask`: empty currency → `"0"`, and default `custom` type

**`src/utils/toPattern.test.ts`** (new file)
- placeholder filling of remaining magic characters (covers `addPlaceholder`)
- string vs object option pattern, literal-separator handling, non-matching input, empty input

**`src/components/MaskedTextInput.test.tsx`**
- controlled `value` prop updates for masked, unmasked, and reset-to-default cases
- currency default value rendering

## Coverage

| | before | after |
|---|---|---|
| All files (stmts) | 74.39% | 88.41% |
| MaskedTextInput.tsx | 96.61% | 100% |
| addPlaceholder.ts | 28.57% | 100% |

## Note (not fixed here)

While covering `mask.ts`, I found the `autoCapitalize` switch (lines 40-44) is effectively a **no-op**: `sentence.toUpperCase()` / `sentence.replace(...)` results are computed but never assigned back, so autoCapitalize never changes the output. I left it out of this PR to avoid encoding broken behavior in a test — happy to follow up with a fix if you'd like.

## Test plan
- [x] `yarn test` — 48 passing (was 23)
- [x] `yarn lint` — 0 errors (pre-existing warnings in `mask.ts` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)