### PR TITLE
fix: return '0' when unMasking a currency value with no digits

### DIFF
--- a/src/utils/mask.test.ts
+++ b/src/utils/mask.test.ts
@@ -132,6 +132,13 @@ test('should unMask an empty currency value to zero', () => {
   expect(received).toBe(expected)
 })
 
+test('should unMask currency with no digits as 0', () => {
+  const expected = '0'
+  const received = unMask('$', 'currency')
+
+  expect(received).toBe(expected)
+})
+
 test('should default the unMask type to custom', () => {
   const expected = 'ABC123'
   const received = unMask('ABC-123')

--- a/src/utils/mask.ts
+++ b/src/utils/mask.ts
@@ -15,6 +15,8 @@ function unMask(value: string, type: 'custom' | 'currency' = 'custom') {
     if (!value) return '0'
 
     const unMaskedValue = value.replace(/\D/g, '')
+    if (!unMaskedValue) return '0'
+
     const number = parseInt(unMaskedValue.trimStart())
 
     return number.toString()


### PR DESCRIPTION
## Problem

`unMask` returns the literal string `"NaN"` for any `currency` value that contains no digits.

```ts
unMask('$', 'currency')   // => "NaN"  (expected "0")
unMask('-', 'currency')   // => "NaN"
unMask('R$', 'currency')  // => "NaN"
```

The digit-stripping step produces an empty string, and `parseInt('')` is `NaN`, so `number.toString()` yields `"NaN"`. This can surface in a `MaskedTextInput` with `type="currency"` when the field is cleared to just its prefix/symbol, feeding `"NaN"` into downstream state or validation.

## Fix

After stripping non-digits, if nothing remains, return `'0'` — consistent with the existing `if (!value) return '0'` guard for empty input.

```ts
const unMaskedValue = value.replace(/\D/g, '')
if (!unMaskedValue) return '0'
```

## Test

Added a case to `src/utils/mask.test.ts`:

```ts
test('should unMask currency with no digits as 0', () => {
  expect(unMask('$', 'currency')).toBe('0')
})
```

All existing tests continue to pass (`yarn jest src/utils/mask.test.ts`).