### PR TITLE
ci: split test workflow into parallel lint/test/build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,42 @@ name: ci
 on: [pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn jest
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -12,25 +48,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
+          cache: yarn
 
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ~/cache
-            !~/cache/exclude
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: yarn install
-
-      - name: Lint
-        run: yarn lint
-
-      - name: Test
-        run: yarn jest
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn prepare


### PR DESCRIPTION
## What

Splits the pull-request CI workflow (`.github/workflows/ci.yml`) into three parallel jobs — `lint`, `test`, and `build` — replacing the single combined `build` job.

- Each job now surfaces as its own PR status check: `ci / lint`, `ci / test`, `ci / build`.
- Switches to `setup-node`'s built-in `cache: yarn` (replaces the manual `actions/cache` block).
- Uses `yarn install --frozen-lockfile` for reproducible installs.

## Why

The workflow previously ran lint, test, and build inside one job named `build`, which made it look like there was no test coverage on PRs. Splitting into named jobs makes the test check visible at a glance, lets the checks run concurrently, and gives a clearer signal about exactly what failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)